### PR TITLE
Upgrade 'spring-boot-starter-web' from 2.6.2 to 2.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
         <restassured.version>3.2.0</restassured.version>
 
-        <spring-boot.version>2.6.2</spring-boot.version>
+        <spring-boot.version>2.6.6</spring-boot.version>
 
         <testng.version>7.1.0</testng.version>
     </properties>


### PR DESCRIPTION
Upgrades [spring-boot-starter-web](https://github.com/spring-projects/spring-boot) from 2.6.2 to 2.6.6.
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.6.2...v2.6.6)

---
updated-dependencies:
- dependency-name: org.springframework.boot:spring-boot-starter-web dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>